### PR TITLE
feat: limpar campos de endereco quando cep nao e valido

### DIFF
--- a/html/login.html
+++ b/html/login.html
@@ -11,13 +11,13 @@
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="../css/style.css" />
-    <link rel="stylesheet" href="../css/login.css">
+    <link rel="stylesheet" href="../css/login.css" />
     <title>Entrar</title>
   </head>
   <body>
     <header>
       <nav class="navbar navbar-expand-md navbar-light bg-light px-5">
-        <a class="navbar-brand" id="logo" href="./index.html">ResiliaFlix</a>
+        <a class="navbar-brand" id="logo" href="../index.html">ResiliaFlix</a>
         <button
           class="navbar-toggler"
           type="button"
@@ -59,7 +59,6 @@
     </header>
 
     <main class="container">
-
       <form class="column g-3 offset-md-4">
         <div class="mb-3">
           <h4>Faça seu login</h4>
@@ -67,11 +66,11 @@
 
         <div class="my-2 col-md-6">
           <label for="name" class="form-label">Email</label>
-          <input type="name" class="form-control" id="inputname">
+          <input type="name" class="form-control" id="inputname" />
         </div>
         <div class="mb-2 col-md-2">
           <label for="inputPassword4" class="form-label">Senha</label>
-          <input type="password" class="form-control" id="inputPassword4">
+          <input type="password" class="form-control" id="inputPassword4" />
         </div>
         <div class="my-4 col-12">
           <button type="submit" class="btn btn-primary">Enviar</button>

--- a/js/cadastro.js
+++ b/js/cadastro.js
@@ -12,7 +12,25 @@ $("#inputZip").keyup(function (event) {
   if ($(this).val().length == 8) {
     buscarEndereco($(this).val().substring(0, 8));
   }
+
+  if ($(this).val().length < 8) {
+    limparEndereco();
+  }
 });
+
+$("#inputZip").on("input", function () {
+  if ($(this).val().length > 8) {
+    $(this).val($(this).val().slice(0, 8));
+  }
+});
+
+function limparEndereco() {
+  $("#inputRua").val("");
+  $("#inputComplemento").val("");
+  $("#inputBairro").val("");
+  $("#inputCity").val("");
+  $("#inputState").val("");
+}
 
 function mostrarEndereco(endereco) {
   $("#inputRua").val(endereco.logradouro);
@@ -27,6 +45,7 @@ function buscarEndereco(cep) {
     url: `https://viacep.com.br/ws/${cep}/json/`,
     success: function (result) {
       if (result["erro"]) {
+        limparEndereco();
         alert("CEP inválido!");
         return;
       }


### PR DESCRIPTION
Atualiza os campos de endereço quando o campo cep é alterado.
Impede que o usuário escreva mais dígitos do que o permitido no campo cep.